### PR TITLE
WL-2913 Pass ISO-8859-1 straight through.

### DIFF
--- a/tool/src/java/org/sakaiproject/evaluation/tool/reporting/ReportExporterBean.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/reporting/ReportExporterBean.java
@@ -109,7 +109,7 @@ public class ReportExporterBean {
 			// This will replace all non US-ASCII characters with '?'
 			// Although this behaviour is unspecified doing it manually is overkill (too much work).
 			// Make sure we escape double quotes.
-			String iso8859Filename = new String(filename.getBytes("ISO-8859-1"))
+			String iso8859Filename = new String(filename.getBytes("ISO-8859-1"), "ISO-8859-1")
 					.replace("\\", "\\\\")
 					.replace("\"", "\\\"");
 			String utf8Filename = URLEncoder.encode(filename, "UTF-8").replace("+", "%20");

--- a/tool/src/test/org/sakaiproject/evaluation/tool/reporting/ReportExporterBeanTest.java
+++ b/tool/src/test/org/sakaiproject/evaluation/tool/reporting/ReportExporterBeanTest.java
@@ -42,4 +42,11 @@ public class ReportExporterBeanTest{
 				"filename*=UTF-8''%CE%93%CE%B5%CE%B9%CE%B1%20%CF%83%CE%B1%CF%82%20%CE%BA%CF%8C%CF%83%CE%BC%CE%BF.txt",
 				exporter.buildContentDisposition("\u0393\u03B5\u03B9\u03B1 \u03C3\u03B1\u03C2 \u03BA\u03CC\u03C3\u03BC\u03BF.txt"));
 	}
+
+	@Test
+	public void testContentDispositionISO8859() {
+		// This is in the high bits of ISO-8859-1 and has a different encoding in UTF-8
+		assertEquals("inline; filename=\"\u00E9.txt\"; filename*=UTF-8''%C3%A9.txt",
+				exporter.buildContentDisposition("\u00E9.txt"));
+	}
 }


### PR DESCRIPTION
This was a problem whereby high bit ISO-8859-1 character which don't encode in UTF-8 the same would get lost as we were creating the string from bytes but not specifying they were in ISO-8859-1.
