### PR TITLE
WL-3274 Don't fall on bad style attributes.

### DIFF
--- a/tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
@@ -343,22 +343,28 @@ public class PDFReportExporter implements ReportExporter {
     }
 
 
-    private float calculateFontSize(String itemText)
+    float calculateFontSize(String itemText)
     {
         //20140226 - daniel.merino@unavarra.es - https://jira.sakaiproject.org/browse/EVALSYS-1100
-        int fontIndex = itemText.indexOf("font-size:");
-        String itemSize;
-        if (fontIndex!=-1) itemSize=itemText.substring(fontIndex+10,itemText.indexOf(";", fontIndex+10)).trim();
-        else return 10.0f;
+        Matcher matcher = Pattern.compile("font-size:\\W*([a-zA-Z-]+)?").matcher(itemText);
+        if (matcher.find())
+        {
+            String itemSize = matcher.group(1);
 
-        //Switch not available for Strings until Java 1.7
-        if (itemSize.equals("xx-large")) return 24.0f;
-        else if (itemSize.equals("x-large")) return 18.0f;
-        else if (itemSize.equals("large")) return 14.0f;
-        else if (itemSize.equals("medium")) return 12.0f;
-        else if (itemSize.equals("small")) return 10.0f;
+            //Switch not available for Strings until Java 1.7
+            if ("xx-large".equals(itemSize)) return 24.0f;
+            else if ("x-large".equals(itemSize)) return 18.0f;
+            else if ("large".equals(itemSize))return 14.0f;
+            else if ("medium".equals(itemSize)) return 12.0f;
+            else if ("small".equals(itemSize)) return 10.0f;
 
-        return 12.0f;
+            // If we have a font size but can't work out what it is attempt to model it on the medium which is
+            // slightly bigger than the default font size.
+            return 12.0f;
+        }
+
+        return 10.0f;
+
     }
 
     private int numberAnswersInQuestion(int [] values, boolean usaNA)

--- a/tool/src/test/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterFontSizeTest.java
+++ b/tool/src/test/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterFontSizeTest.java
@@ -1,0 +1,46 @@
+package org.sakaiproject.evaluation.tool.reporting;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PDFReportExporterFontSizeTest {
+
+	// Accuracy of floating point comparisons.
+	private static final double DELTA = 1e-6;
+	private PDFReportExporter exporter;
+
+	@Before
+	public void setUp() {
+		exporter = new PDFReportExporter();
+
+	}
+
+	@Test
+	public void testSimpleFontSize() {
+		assertEquals(14.0f, exporter.calculateFontSize("<div style='font-size: large; color: blue'>Hello</div>"), DELTA);
+	}
+
+	@Test
+	public void testJustDefaultFontSize() {
+		assertEquals(10.0f, exporter.calculateFontSize("<div>Hello</div>"), DELTA);
+	}
+
+	@Test
+	public void testFontSizeNumeric() {
+		// If we have a font style but can't understand it we have a slightly larger font.
+		assertEquals(12.0f, exporter.calculateFontSize("<div style='font-size: 12pt;'>Hello</div>"), DELTA);
+	}
+
+	@Test
+	public void testFontSizeNoSemiColon() {
+		assertEquals(14.0f, exporter.calculateFontSize("<div style='font-size: large'>Hello</div>"), DELTA);
+	}
+
+	@Test
+	public void testFontSizeNoSpavce() {
+		assertEquals(14.0f, exporter.calculateFontSize("<div style='font-size:large;'>Hello</div>"), DELTA);
+	}
+
+}

--- a/tool/src/test/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterFontSizeTest.java
+++ b/tool/src/test/org/sakaiproject/evaluation/tool/reporting/PDFReportExporterFontSizeTest.java
@@ -39,7 +39,7 @@ public class PDFReportExporterFontSizeTest {
 	}
 
 	@Test
-	public void testFontSizeNoSpavce() {
+	public void testFontSizeNoSpace() {
 		assertEquals(14.0f, exporter.calculateFontSize("<div style='font-size:large;'>Hello</div>"), DELTA);
 	}
 


### PR DESCRIPTION
If the style attribute didn't contain a semicolon then you get an index out of bounds exception. Now we use a regexp so we don't require a trailing colon.
