### PR TITLE
WL-3479 Rework date picker to use new one.

### DIFF
--- a/tool/src/java/org/sakaiproject/evaluation/tool/evolvers/NewFieldDateInputEvolver.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/evolvers/NewFieldDateInputEvolver.java
@@ -1,0 +1,87 @@
+package org.sakaiproject.evaluation.tool.evolvers;
+
+import org.sakaiproject.evaluation.tool.utils.ISO8601FieldDateTransit;
+import uk.org.ponder.beanutil.BeanGetter;
+import uk.org.ponder.rsf.components.*;
+import uk.org.ponder.rsf.evolvers.FormatAwareDateInputEvolver;
+import uk.org.ponder.rsf.util.RSFUtil;
+
+import java.util.Date;
+
+/**
+ * Unlike the original date formatter we no longer do the parsing on the client side as we just
+ * expect a ISO8601 formatted date from all languages.
+ */
+public class NewFieldDateInputEvolver implements FormatAwareDateInputEvolver {
+
+	// This is the RSF ID that will be looked up in the templates to decide which one to use.
+	public static final String COMPONENT_ID = "new-date-field-input:";
+
+	private String style = DATE_INPUT;
+	// The transit base is the bean looked up to convert data between the request and model.
+	// In this case we need to translate between a string and date.
+	private String transitBase = "iso8601DateTransit";
+
+	private BeanGetter rbg;
+
+	public void setInvalidDateKey(String s) {
+
+	}
+	public void setRequestBeanGetter(BeanGetter rbg) {
+		this.rbg = rbg;
+	}
+
+
+	public UIJointContainer evolveDateInput(UIInput toEvolve, Date value) {
+		// Pull in the template
+		UIJointContainer togo = new UIJointContainer(toEvolve.parent, toEvolve.ID, COMPONENT_ID);
+		// Remove the existing component from the tree
+		toEvolve.parent.remove(toEvolve);
+		String transitBean = transitBase + "." + togo.getFullID();
+
+		// Need ISO9601 support.
+		ISO8601FieldDateTransit transit = (ISO8601FieldDateTransit) rbg.getBean(transitBean);
+		if (value == null) {
+			// The UIInput we're evolving must have a OTP bean for this to work.
+			value = (Date) rbg.getBean(toEvolve.valuebinding.value);
+		}
+		if (value != null) {
+			transit.setDate(value);
+		}
+
+		String ttb = transitBean + ".";
+
+		UIOutput display = UIOutput.make(togo, "display");
+
+
+		UIInput field = UIInput.make(togo, "iso8601", ttb + "ISO8601", transit.getISO8601());
+		field.mustapply = true;
+
+		// Bind the value back through to the transitBase.
+		// This generates a custom hidden HTML
+		UIForm form = RSFUtil.findBasicForm(togo);
+		form.parameters.add(new UIELBinding(toEvolve.valuebinding.value,
+				new ELReference(ttb + "date")));
+
+		UIInitBlock.make(togo, "init-date", "rsfDatePicker", new Object[] {
+				display.getFullID(), field.getFullID(),
+				// If we just supply a boolean it is output as a string which doesn't work.
+				(style.equals(DATE_TIME_INPUT) || style.equals(TIME_INPUT))?1:0
+		});
+
+		return togo;
+	}
+
+	public UIJointContainer evolveDateInput(UIInput toEvolve) {
+		return evolveDateInput(toEvolve, null);
+	}
+
+	public void setInvalidTimeKey(String s) {
+
+	}
+
+	public void setStyle(String s) {
+		this.style = s;
+	}
+
+}

--- a/tool/src/java/org/sakaiproject/evaluation/tool/producers/EvaluationSettingsProducer.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/producers/EvaluationSettingsProducer.java
@@ -15,6 +15,7 @@
 package org.sakaiproject.evaluation.tool.producers;
 
 import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -31,6 +32,7 @@ import org.sakaiproject.evaluation.logic.model.EvalUser;
 import org.sakaiproject.evaluation.model.EvalEvaluation;
 import org.sakaiproject.evaluation.model.EvalTemplate;
 import org.sakaiproject.evaluation.tool.EvalToolConstants;
+import org.sakaiproject.evaluation.tool.evolvers.NewFieldDateInputEvolver;
 import org.sakaiproject.evaluation.tool.renderers.NavBarRenderer;
 import org.sakaiproject.evaluation.tool.utils.RSFUtils;
 import org.sakaiproject.evaluation.tool.viewparams.AdminSearchViewParameters;
@@ -58,17 +60,17 @@ import uk.org.ponder.rsf.components.UISelect;
 import uk.org.ponder.rsf.components.UISelectChoice;
 import uk.org.ponder.rsf.components.UISelectLabel;
 import uk.org.ponder.rsf.components.UIVerbatim;
-import uk.org.ponder.rsf.components.decorators.DecoratorList;
-import uk.org.ponder.rsf.components.decorators.UILabelTargetDecorator;
-import uk.org.ponder.rsf.components.decorators.UITextDimensionsDecorator;
-import uk.org.ponder.rsf.components.decorators.UITooltipDecorator;
+import uk.org.ponder.rsf.components.decorators.*;
+import uk.org.ponder.rsf.evolvers.DateInputEvolver;
 import uk.org.ponder.rsf.evolvers.FormatAwareDateInputEvolver;
 import uk.org.ponder.rsf.evolvers.TextInputEvolver;
 import uk.org.ponder.rsf.flow.ARIResult;
 import uk.org.ponder.rsf.flow.ActionResultInterceptor;
 import uk.org.ponder.rsf.util.RSFUtil;
+import uk.org.ponder.rsf.util.html.RSFHTMLUtil;
 import uk.org.ponder.rsf.view.ComponentChecker;
 import uk.org.ponder.rsf.view.ViewComponentProducer;
+import uk.org.ponder.rsf.view.ViewRoot;
 import uk.org.ponder.rsf.viewstate.SimpleViewParameters;
 import uk.org.ponder.rsf.viewstate.ViewParameters;
 import uk.org.ponder.rsf.viewstate.ViewParamsReporter;
@@ -107,11 +109,6 @@ public class EvaluationSettingsProducer implements ViewComponentProducer, ViewPa
         this.authoringService = authoringService;
     }
 
-    private FormatAwareDateInputEvolver dateevolver;
-    public void setDateEvolver(FormatAwareDateInputEvolver dateevolver) {
-        this.dateevolver = dateevolver;
-    }
-
     private TextInputEvolver richTextEvolver;
     public void setRichTextEvolver(TextInputEvolver richTextEvolver) {
         this.richTextEvolver = richTextEvolver;
@@ -125,6 +122,11 @@ public class EvaluationSettingsProducer implements ViewComponentProducer, ViewPa
     private NavBarRenderer navBarRenderer;
     public void setNavBarRenderer(NavBarRenderer navBarRenderer) {
 		this.navBarRenderer = navBarRenderer;
+	}
+
+	private FormatAwareDateInputEvolver dateEvolver;
+	public void setDateEvolver(FormatAwareDateInputEvolver dateEvolver) {
+		this.dateEvolver = dateEvolver;
 	}
 
     /* (non-Javadoc)
@@ -294,19 +296,19 @@ public class EvaluationSettingsProducer implements ViewComponentProducer, ViewPa
 
         // Start Date
         UIBranchContainer showStartDate = UIBranchContainer.make(form, "showStartDate:");
-        generateDateSelector(showStartDate, "startDate", evaluationOTP + "startDate", 
+        generateDateSelector(showStartDate, "startDate", evaluationOTP + "startDate",
                 null, currentEvalState, EvalConstants.EVALUATION_STATE_ACTIVE, useDateTime);
 
         // Due Date
         UIBranchContainer showDueDate = UIBranchContainer.make(form, "showDueDate:");
-        generateDateSelector(showDueDate, "dueDate", evaluationOTP + "dueDate", 
+        generateDateSelector(showDueDate, "dueDate", evaluationOTP + "dueDate",
                 reOpenDueDate, currentEvalState, EvalConstants.EVALUATION_STATE_GRACEPERIOD, useDateTime);
 
         // Stop Date - Show the "Stop date" text box only if allowed in the System settings
         Boolean useStopDate = (Boolean) settings.get(EvalSettings.EVAL_USE_STOP_DATE);
         if (useStopDate) {
             UIBranchContainer showStopDate = UIBranchContainer.make(form, "showStopDate:");
-            generateDateSelector(showStopDate, "stopDate", evaluationOTP + "stopDate", 
+            generateDateSelector(showStopDate, "stopDate", evaluationOTP + "stopDate",
                     reOpenStopDate, currentEvalState, EvalConstants.EVALUATION_STATE_CLOSED, useDateTime);
         }
 
@@ -620,11 +622,11 @@ public class EvaluationSettingsProducer implements ViewComponentProducer, ViewPa
         } else {
             UIInput datePicker = UIInput.make(parent, rsfId + ":", binding);
             if (useDateTime) {
-                dateevolver.setStyle(FormatAwareDateInputEvolver.DATE_TIME_INPUT);         
+                dateEvolver.setStyle(FormatAwareDateInputEvolver.DATE_TIME_INPUT);
             } else {
-                dateevolver.setStyle(FormatAwareDateInputEvolver.DATE_INPUT);        
+                dateEvolver.setStyle(FormatAwareDateInputEvolver.DATE_INPUT);
             }
-            dateevolver.evolveDateInput(datePicker, initValue);
+            dateEvolver.evolveDateInput(datePicker, initValue);
         }
     }
 
@@ -650,13 +652,7 @@ public class EvaluationSettingsProducer implements ViewComponentProducer, ViewPa
                 UIMessage.make(parent, rsfId + "_label", "evalsettings.view.results.date.label");
             } else {
                 // allow them to choose the date using a date picker
-                UIInput dateInput = UIInput.make(parent, rsfId + ":", binding);
-                if (useDateTime) {
-                    dateevolver.setStyle(FormatAwareDateInputEvolver.DATE_TIME_INPUT);         
-                } else {
-                    dateevolver.setStyle(FormatAwareDateInputEvolver.DATE_INPUT);        
-                }
-                dateevolver.evolveDateInput(dateInput);
+                UIInput dateInput = UIInput.make(parent, rsfId + "-iso8601", binding);
             }         
         }
     }

--- a/tool/src/java/org/sakaiproject/evaluation/tool/utils/ISO8601FieldDateTransit.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/utils/ISO8601FieldDateTransit.java
@@ -1,0 +1,37 @@
+package org.sakaiproject.evaluation.tool.utils;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * The new date widget always sends back a ISO8601 formatted string. If the user
+ * doesn't have JavaScript they can't enter a date so we don't need to worry about
+ * falling back to doing locale based parsing of dates.
+ */
+public class ISO8601FieldDateTransit {
+
+	public static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
+	private Date date;
+
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
+	public String getISO8601() {
+		return (date == null)?null:new SimpleDateFormat(ISO_FORMAT).format(date);
+	}
+
+	public void setISO8601(String source) {
+		try {
+			// This shouldn't ever fail as we should be getting it from the widget.
+			date = new SimpleDateFormat(ISO_FORMAT).parse(source);
+		} catch (ParseException pe) {
+			throw new RuntimeException(pe);
+		}
+	}
+}

--- a/tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/tool/src/webapp/WEB-INF/applicationContext.xml
@@ -32,11 +32,12 @@
     <bean parent="requestAddressibleParent">
         <property name="value"
             value="id-defunnel, adhocGroupsBean, adhocGroupMemberRemovalBean, sendEmailsBean,
-		      setupEvalBean, reportsBean, templateBBean, importBean, itemsBean, expertItemsBean, 
-		      templateBeanLocator, templateItemWBL, answersBeanLocator, responseAnswersBeanLocator, responseBeanLocator, 
-		      evaluationBeanLocator, takeEvalBean, settingsBean, scaleBean, scaleBeanLocator, itemWBL, 
-		      hierNodeLocator, hierNodeLocatorInvoker, hierNodeGroupsLocator, hierNodeGroupsLocatorInvoker,
-              emailTemplateWBL, administrateSearchBean, selectedEvaluationUsersLocator, assignGroupSelectionSettings" />
+          setupEvalBean, reportsBean, templateBBean, importBean, itemsBean, expertItemsBean,
+          templateBeanLocator, templateItemWBL, answersBeanLocator, responseAnswersBeanLocator, responseBeanLocator,
+          evaluationBeanLocator, takeEvalBean, settingsBean, scaleBean, scaleBeanLocator, itemWBL,
+          hierNodeLocator, hierNodeLocatorInvoker, hierNodeGroupsLocator, hierNodeGroupsLocatorInvoker,
+              emailTemplateWBL, administrateSearchBean, selectedEvaluationUsersLocator, assignGroupSelectionSettings,
+              iso8601DateTransit" />
     </bean>
 
     <!-- allows us to identify entities used in OTP on the EL path,
@@ -184,8 +185,8 @@
         <property name="baseDirectory" value="component-templates/" />
         <property name="templateNames"
             value="render_header_item, render_text_item, render_scaled_item, render_block_item, 
-			     render_multiplechoice_item, render_multipleanswer_item,
-			     render_add_item_control, hierarchy_controls, render_hierarchy_node_selector, nav_bar" />
+           render_multiplechoice_item, render_multipleanswer_item,
+           render_add_item_control, hierarchy_controls, render_hierarchy_node_selector, nav_bar, new_date_field_input" />
         <property name="expected" value="true" />
     </bean>
 

--- a/tool/src/webapp/WEB-INF/requestContext.xml
+++ b/tool/src/webapp/WEB-INF/requestContext.xml
@@ -543,9 +543,13 @@
             ref="org.sakaiproject.evaluation.logic.EvalEvaluationService" />
         <property name="authoringService"
             ref="org.sakaiproject.evaluation.logic.EvalAuthoringService" />
-        <property name="dateEvolver" ref="fieldDateInputEvolver" />
         <property name="richTextEvolver" ref="richTextEvolver" />
         <property name="locale" ref="requestLocale" />
+        <property name="dateEvolver">
+            <bean class="org.sakaiproject.evaluation.tool.evolvers.NewFieldDateInputEvolver">
+              <property name="requestBeanGetter" ref="ELEvaluator" />
+            </bean>
+        </property>
 		<property name="navBarRenderer" ref="navBarRenderer" />	
     </bean>
 
@@ -745,5 +749,12 @@
 
 	<!-- Flow cycle messages view -->
 	 <bean class="org.sakaiproject.evaluation.tool.producers.MessagesProducer" />
+
+  <!-- Used for converting ISO8601 dates to Dates (Java) -->
+  <bean id="iso8601DateTransit" parent="beanExploder">
+    <property name="factory">
+      <bean class="org.sakaiproject.evaluation.tool.utils.ISO8601FieldDateTransit"/>
+    </property>
+  </bean>
 	
 </beans>

--- a/tool/src/webapp/component-templates/new_date_field_input.html
+++ b/tool/src/webapp/component-templates/new_date_field_input.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns:rsf="http://ponder.org.uk/rsf" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <!-- These need to be pulled in all the time and the rsf:id does this. -->
+    <script type="text/javascript" src="/library/js/jquery/jquery-1.9.1.min.js" rsf:id="scr=contribute-script"></script>
+    <script type="text/javascript" src="/library/js/jquery/ui/1.10.3/jquery-ui.1.10.3.full.min.js" rsf:id="scr=contribute-script"></script>
+    <link href="/library/js/jquery/ui/1.10.3/css/ui-lightness/jquery-ui-1.10.3.custom.min.css" rel="stylesheet" type="text/css" rsf:id="scr=contribute-style" />
+    <script type="text/javascript" src="/library/js/lang-datepicker/lang-datepicker.js" rsf:id="scr=contribute-script"></script>
+    <script type="text/javascript" rsf:id="scr=contribute-script">
+        // Simple wrapper to make it easy to call from RSF.
+        var rsfDatePicker = function(id, hidden, time){
+            // jQuery selectors need colons escaped.
+            id = "#"+ id.replace(/:/g, "\\:");
+            hidden = hidden.replace(/:/g, "\\:");
+            // Load plugin on DOM ready.
+            $(function() {
+                $(id).sakaiDateTimePicker({
+                    input: id,
+                    useTime: time,
+                    parseFormat: 'YYYY-MM-DD HH:mm:ss',
+                    getval: "#"+hidden,
+                    ashidden: { iso8601: hidden }
+                });
+            });
+        };
+    </script>
+</head>
+
+<body>
+
+<!-- We have 2 HTML tags, one that is displayed to the user and one that stores our ISO8601 formatted date.
+     JavaScript is used to copy that updates between the two. This means if JS isn't enabled this won't work.
+  -->
+<!-- The root of the component -->
+<div rsf:id="new-date-field-input:">
+    <input rsf:id="iso8601" type="hidden"
+           id="dateStart" name="dateStart" value="MM/DD/YYYY"
+           size="15" maxlength="15" />
+    <input rsf:id="display" type="text" id="startDate" name="startDate" />
+    <script rsf:id="init-date">
+        rsfDatePicker(id, hidden, time);
+    </script>
+</div>
+
+</body>
+</html>

--- a/tool/src/webapp/content/templates/evaluation_settings.html
+++ b/tool/src/webapp/content/templates/evaluation_settings.html
@@ -7,11 +7,12 @@
 		<link href="/library/skin/tool_base.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 		<link href="/library/skin/default/tool.css" rsf:id="scr=portal-matter" type="text/css" rel="stylesheet" media="all"/>
 		<script type="text/javascript" rsf:id="scr=portal-matter" language="JavaScript" src="/library/js/headscripts.js"></script>
-        <script type="text/javascript" language="JavaScript" src="../js/jquery/jquery.js"></script>
-        <script type="text/javascript" language="JavaScript" src="../js/evalUtils.js"></script>
-        <script type="text/javascript" language="JavaScript" src="../js/eval.settings.js"></script>
+		<!-- This has to come out as the date widget will inject it into the page.
+		    <script type="text/javascript" src="/library/js/jquery/jquery-1.9.1.min.js"></script>
+		  -->
+		<script type="text/javascript" language="JavaScript" src="../js/evalUtils.js"></script>
+		<script type="text/javascript" language="JavaScript" src="../js/eval.settings.js"></script>
 		<link href="../css/evaluation_base.css" type="text/css" rel="stylesheet" media="all" />
-		
 	</head>
 	<body>
 		<div class="portletBody">
@@ -79,40 +80,37 @@
 
 				<fieldset class="visibleFS">
 					<legend rsf:id="msg=evalsettings.dates.header">Evaluation Dates:</legend>
-                        <div class="shorttext">
-                            <span rsf:id="current_date" class="instruction textPanelFooter">
-                                Today is Oct 29, 1975
-                            </span>
-                        </div>
-						<div rsf:id="showStartDate:" class="shorttext">
-							<label rsf:id="msg=evalsettings.start.date.header" for="startDate:::date-field">Start Date:</label>
-							<span  rsf:id="startDate:">
-							  <input type="text" id="start_date_dummy" name="start_date_dummy" value="MM/DD/YYYY" size="12" maxlength="10"/>
-							  <img src="../images/calendar.gif" />
+						<div class="shorttext">
+							<span rsf:id="current_date" class="instruction textPanelFooter">
+								Today is Oct 29, 1975
 							</span>
-                            <span rsf:id="startDate_disabled" />
-							<span rsf:id="msg=evalsettings.start.date.desc"  class="instruction textPanelFooter">
-								Users may begin submitting evaluation responses on this date
+						</div>
+						<div rsf:id="showStartDate:" class="shorttext">
+							<label rsf:id="msg=evalsettings.start.date.header" for="startDate">Start Date:</label>
+							<input rsf:id="startDate:" type="hidden"
+									id="dateStart" name="dateStart" value="MM/DD/YYYY"
+									size="15" maxlength="15" />
+							<span rsf:id="startDate_disabled" />
+							<span rsf:id="msg=evalsettings.start.date.desc" class="instruction textPanelFooter">
+								Evaluation ends on this date, no more responses after this date
 							</span>
 						</div>
 						<div rsf:id="showDueDate:" class="shorttext">
-							<label rsf:id="msg=evalsettings.due.date.header" for="dueDate:::date-field">Due Date:</label>
-							<span rsf:id="dueDate:">
-								<input type="text" name="date_dummy" value="MM/DD/YYYY" size="12" maxlength="10"/>
-								<img src="../images/calendar.gif" />
-							</span>
-                            <span rsf:id="dueDate_disabled" />
+							<label rsf:id="msg=evalsettings.due.date.header" for="dueDate">Due Date:</label>
+							<input rsf:id="dueDate:" type="hidden"
+								   id="dateDue" name="dateDue" value="MM/DD/YYYY"
+								   size="15" maxlength="15" />
+							<span rsf:id="dueDate_disabled" />
 							<span rsf:id="msg=evalsettings.due.date.desc" class="instruction textPanelFooter">
 								Evaluation ends on this date, no more responses after this date
 							</span>
 						</div>
 						<div rsf:id="showStopDate:" class="shorttext">
-							<label rsf:id="msg=evalsettings.stop.date.header" for="stopDate:::date-field">Stop Date:</label>
-							<span style="display:inline" rsf:id="stopDate:">
-								<input type="text" name="date_dummy" value="MM/DD/YYYY" size="12" maxlength="10"/>
-								<img src="../images/calendar.gif" />
-							</span>
-                            <span rsf:id="stopDate_disabled" />
+							<label rsf:id="msg=evalsettings.stop.date.header" for="stopDate">Stop Date:</label>
+							<input rsf:id="stopDate" type="hidden"
+								   id="dateStop" name="dateStop" value="MM/DD/YYYY"
+								   size="15" maxlength="15" />
+							<span rsf:id="stopDate_disabled" />
 							<span rsf:id="msg=evalsettings.stop.date.desc" class="instruction textPanelFooter">
 								Users may still submit responses up until this date (defines a grace period)
 							</span>
@@ -142,18 +140,17 @@
 						Note that admins above in the hierarchy can view the results UNLESS results sharing is set to private
 					  </p>
 					   
-                    </div>
-                    <div rsf:id="showViewDate:" class="shorttext" id="evaluation_show_viewdate_area">
-                         <label rsf:id="msg=evalsettings.view.date.header" for="viewDate:::date-field">View Date:</label>
-                         <span rsf:id="viewDate:">
-                             <input type="text" name="date_dummy" value="MM/DD/YYYY" size="12" maxlength="10"/>
-                             <img src="../images/calendar.gif" />
-                         </span>
-                         <span rsf:id="viewDate_disabled" />
-                         <span rsf:id="msg=evalsettings.view.date.desc" class="instruction textPanelFooter">
-                             Results are not viewable until this date
-                         </span>
-                    </div>
+					</div>
+					<div rsf:id="showViewDate:" class="shorttext" id="evaluation_show_viewdate_area">
+						 <label rsf:id="msg=evalsettings.view.date.header" for="viewDate">View Date:</label>
+						<input rsf:id="viewDate:" type="hidden"
+							   id="viewDate" name="dateDue" value="MM/DD/YYYY"
+							   size="15" maxlength="15" />
+						<span rsf:id="viewDate_disabled" />
+						<span rsf:id="msg=evalsettings.view.date.desc" class="instruction textPanelFooter">
+							 Results are not viewable until this date
+						 </span>
+					</div>
 					<table class="listHier" border="0" cellspacing="0" cellpadding="0" width="99%" style="margin:0" id="evaluation_show_results_area"><!-- DO NOT CHANGE THIS ID, it is used by JS logic -AZ -->
 						<tr rsf:id="showResultsToStudents:" id="showResultsToStudents">
 							<td width="50%" class="checkbox">


### PR DESCRIPTION
This creates an RSF evolver so that the date component is re-useable and the model doesn’t have to be altered to support the new format that comes back from the request.

The evolver is going back into mainline RSF but as we don’t want to wait for that to happen and we also aren’t yet on the latest version of RSF we are putting the code directly into the evaluations tool.
