### PR TITLE
WL-3556 Missing colon broke settings page.

### DIFF
--- a/tool/src/webapp/content/templates/evaluation_settings.html
+++ b/tool/src/webapp/content/templates/evaluation_settings.html
@@ -107,7 +107,7 @@
 						</div>
 						<div rsf:id="showStopDate:" class="shorttext">
 							<label rsf:id="msg=evalsettings.stop.date.header" for="stopDate">Stop Date:</label>
-							<input rsf:id="stopDate" type="hidden"
+							<input rsf:id="stopDate:" type="hidden"
 								   id="dateStop" name="dateStop" value="MM/DD/YYYY"
 								   size="15" maxlength="15" />
 							<span rsf:id="stopDate_disabled" />


### PR DESCRIPTION
stopDate didn’t have it’s colon so when the extension date was enabled in the administration page the settings page would fail to render.
