### PR TITLE
WL-1742 Don’t display options that make no sense.

### DIFF
--- a/tool/src/webapp/content/js/eval.settings.js
+++ b/tool/src/webapp/content/js/eval.settings.js
@@ -15,28 +15,13 @@ $(function() {
 			});
 			
 			$(".adminSettings select").change(function(){
-				var changeAnswersArray = $("input[id=showModifyResponsesAllowedToStu::modifyResponsesAllowed]");
-				var evaluatorsTakePartArray = $("input[id=evaluatorsParticipate]");
-				if (this.value == 'NONE') {
-					for (var i=0; i<changeAnswersArray.length; i++) {
-						changeAnswersArray[i].checked=false;
-						changeAnswersArray[i].disabled=true;
-					}
-					for (var i=0; i<evaluatorsTakePartArray.length; i++) {
-						evaluatorsTakePartArray[i].checked=false;
-						evaluatorsTakePartArray[i].disabled=true;
-					}
-				}
-				if (this.value == 'AUTH') {
-					for (var i=0; i<changeAnswersArray.length; i++) {
-						changeAnswersArray[i].checked=true;
-						changeAnswersArray[i].disabled=false;
-					}
-					for (var i=0; i<evaluatorsTakePartArray.length; i++) {
-						evaluatorsTakePartArray[i].checked=true;
-						evaluatorsTakePartArray[i].disabled=false;
-					}
-				}
+				// When the survey doesn't require users to login they can't come back to the survey so some
+				// options in the interface don't makes sense, so we disable them.
+				var nonLoggedIn = this.value ==='NONE';
+				$('input[name="showModifyResponsesAllowedToStu::modifyResponsesAllowed"]')
+					.prop({'disabled': nonLoggedIn, 'checked': !nonLoggedIn});
+				$('input[name="showAllRolesCanParticipate::allRolesParticipate"]')
+					.prop({'disabled': nonLoggedIn, 'checked': !nonLoggedIn});
 			});
 			
 });


### PR DESCRIPTION
When a user doesn’t have to be logged in to take a survey they can’t sensibly come back to the survey and change it. Also when you aren’t required to login you don’t know the role a person is in so there’s no point in having an option for it.

I didn’t collapse the 2 statements down into one to make it a little more readable.
