### PR TITLE
WL-3757 : Unable to generate PDF - block weighted mean problem

### DIFF
--- a/tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
+++ b/tool/src/java/org/sakaiproject/evaluation/tool/reporting/PDFReportExporter.java
@@ -472,10 +472,7 @@ public class PDFReportExporter implements ReportExporter {
 
                 //Reset.
                 processingBlock=false;
-                for (int n=0;n<collectedValues.size();n++)
-                {
-                    collectedValues.set(n,0);
-                }
+                collectedValues = new ArrayList<Integer>();
             }
 
             if (EvalConstants.ITEM_TYPE_BLOCK_PARENT.equals(templateItemType))


### PR DESCRIPTION
The stacktrace happens because after the first Question Block has its weighted mean calculated, the answers are not fully reset and so when it comes to process the 2nd Question Block's weighted mean (during the Multiple Choice question), it thinks it's fine because those (previous) answers were numeric.

This fix tests to see if the answers are numeric and returns -1 if they aren't (-1 is what the code looks for to see if it should ignore it). 
